### PR TITLE
New methods, renaming and .NET 4.5.2

### DIFF
--- a/ActiveDirectoryService.Tests/ActiveDirectoryService.Tests.csproj
+++ b/ActiveDirectoryService.Tests/ActiveDirectoryService.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Affecto.ActiveDirectoryService.Tests</RootNamespace>
     <AssemblyName>Affecto.ActiveDirectoryService.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -30,6 +30,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,6 +39,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/ActiveDirectoryService/ActiveDirectoryService.cs
+++ b/ActiveDirectoryService/ActiveDirectoryService.cs
@@ -19,19 +19,19 @@ namespace Affecto.ActiveDirectoryService
             this.domainPath = domainPath;
         }
 
-        public virtual IPrincipal GetUser(string userName, ICollection<string> additionalPropertyNames = null)
+        public virtual IPrincipal GetPrincipal(string accountName, ICollection<string> additionalPropertyNames = null)
         {
             using (DirectoryEntry domainEntry = new DirectoryEntry(domainPath.GetPathWithProtocol()))
             using (PrincipalSearcher searcher = new PrincipalSearcher(domainEntry, additionalPropertyNames))
             {
-                return searcher.FindPrincipal(userName);
+                return searcher.FindPrincipal(accountName);
             }
         }
 
-        public bool IsGroupMember(string userName, string groupName)
+        public bool IsGroupMember(string accountName, string groupName)
         {
-            return !string.IsNullOrWhiteSpace(userName)
-                && GetGroupMemberAccountNames(groupName).Any(o => o.Equals(userName, StringComparison.OrdinalIgnoreCase));
+            return !string.IsNullOrWhiteSpace(accountName)
+                && GetGroupMemberAccountNames(groupName).Any(o => o.Equals(accountName, StringComparison.OrdinalIgnoreCase));
         }
 
         public virtual IEnumerable<IPrincipal> GetGroupMembers(string groupName, bool recursive, ICollection<string> additionalPropertyNames = null)

--- a/ActiveDirectoryService/ActiveDirectoryService.csproj
+++ b/ActiveDirectoryService/ActiveDirectoryService.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Affecto.ActiveDirectoryService</RootNamespace>
     <AssemblyName>Affecto.ActiveDirectoryService</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/ActiveDirectoryService/ActiveDirectoryService.nuspec
+++ b/ActiveDirectoryService/ActiveDirectoryService.nuspec
@@ -8,7 +8,10 @@
     <projectUrl>https://github.com/affecto/dotnet-ActiveDirectoryService</projectUrl>
     <tags>affecto active directory ad activedirectory wrapper</tags>
     <releaseNotes>
-      Added a method for searching principals using an LDAP query.
+      Raised to .NET Framework 4.5.2. 
+      Added a method for getting principal by its native GUID. 
+      Added a method for getting group members by group native GUID. 
+      Renamed methods and properties to make them more consistent.
     </releaseNotes>
   </metadata>
 </package>

--- a/ActiveDirectoryService/ActiveDirectoryService.nuspec
+++ b/ActiveDirectoryService/ActiveDirectoryService.nuspec
@@ -8,10 +8,10 @@
     <projectUrl>https://github.com/affecto/dotnet-ActiveDirectoryService</projectUrl>
     <tags>affecto active directory ad activedirectory wrapper</tags>
     <releaseNotes>
-      Raised to .NET Framework 4.5.2. 
-      Added a method for getting principal by its native GUID. 
-      Added a method for getting group members by group native GUID. 
-      Renamed methods and properties to make them more consistent.
+Raised to .NET Framework 4.5.2. 
+Added a method for getting principal by its native GUID. 
+Added a method for getting group members by group native GUID. 
+Renamed methods and properties to make them more consistent.
     </releaseNotes>
   </metadata>
 </package>

--- a/ActiveDirectoryService/CachedActiveDirectoryService.cs
+++ b/ActiveDirectoryService/CachedActiveDirectoryService.cs
@@ -31,10 +31,10 @@ namespace Affecto.ActiveDirectoryService
             this.cacheDuration = cacheDuration;
         }
 
-        public override IPrincipal GetUser(string userName, ICollection<string> additionalPropertyNames = null)
+        public override IPrincipal GetPrincipal(string accountName, ICollection<string> additionalPropertyNames = null)
         {
-            string cacheKey = CreateCacheKey(GetUserKey, userName, FormatAdditionalPropertyNames(additionalPropertyNames));
-            return GetCachedValue(GetUserKey, cacheKey, () => base.GetUser(userName, additionalPropertyNames));
+            string cacheKey = CreateCacheKey(GetUserKey, accountName, FormatAdditionalPropertyNames(additionalPropertyNames));
+            return GetCachedValue(GetUserKey, cacheKey, () => base.GetPrincipal(accountName, additionalPropertyNames));
         }
 
         public override IEnumerable<IPrincipal> GetGroupMembers(string groupName, bool recursive, ICollection<string> additionalPropertyNames = null)

--- a/ActiveDirectoryService/CachedActiveDirectoryService.cs
+++ b/ActiveDirectoryService/CachedActiveDirectoryService.cs
@@ -7,7 +7,8 @@ namespace Affecto.ActiveDirectoryService
     internal class CachedActiveDirectoryService : ActiveDirectoryService
     {
         private const string CacheName = "Affecto.ActiveDirectoryService";
-        private const string GetUserKey = "GetUserKey";
+        private const string GetPrincipalByAccountNameKey = "GetPrincipalByAccountNameKey";
+        private const string GetPrincipalByNativeGuidKey = "GetPrincipalByNativeGuidKey";
         private const string GetGroupMembersKey = "GetGroupMembers";
         private const string GetGroupMemberAccountNamesKey = "GetGroupMemberAccountNames";
         private const string SearchPrincipalsKey = "SearchPrincipals";
@@ -16,7 +17,8 @@ namespace Affecto.ActiveDirectoryService
         private static readonly MemoryCache Cache = new MemoryCache(CacheName);
         private static readonly Dictionary<string, object> Locks = new Dictionary<string, object>
         {
-            { GetUserKey, new object() },
+            { GetPrincipalByAccountNameKey, new object() },
+            { GetPrincipalByNativeGuidKey, new object() },
             { GetGroupMembersKey, new object() },
             { GetGroupMemberAccountNamesKey, new object() },
             { SearchPrincipalsKey, new object() },
@@ -33,8 +35,14 @@ namespace Affecto.ActiveDirectoryService
 
         public override IPrincipal GetPrincipal(string accountName, ICollection<string> additionalPropertyNames = null)
         {
-            string cacheKey = CreateCacheKey(GetUserKey, accountName, FormatAdditionalPropertyNames(additionalPropertyNames));
-            return GetCachedValue(GetUserKey, cacheKey, () => base.GetPrincipal(accountName, additionalPropertyNames));
+            string cacheKey = CreateCacheKey(GetPrincipalByAccountNameKey, accountName, FormatAdditionalPropertyNames(additionalPropertyNames));
+            return GetCachedValue(GetPrincipalByAccountNameKey, cacheKey, () => base.GetPrincipal(accountName, additionalPropertyNames));
+        }
+
+        public override IPrincipal GetPrincipal(Guid nativeGuid, ICollection<string> additionalPropertyNames = null)
+        {
+            string cacheKey = CreateCacheKey(GetPrincipalByNativeGuidKey, nativeGuid.ToString("D"), FormatAdditionalPropertyNames(additionalPropertyNames));
+            return GetCachedValue(GetPrincipalByNativeGuidKey, cacheKey, () => base.GetPrincipal(nativeGuid, additionalPropertyNames));
         }
 
         public override IEnumerable<IPrincipal> GetGroupMembers(string groupName, bool recursive, ICollection<string> additionalPropertyNames = null)

--- a/ActiveDirectoryService/CachedActiveDirectoryService.cs
+++ b/ActiveDirectoryService/CachedActiveDirectoryService.cs
@@ -7,9 +7,10 @@ namespace Affecto.ActiveDirectoryService
     internal class CachedActiveDirectoryService : ActiveDirectoryService
     {
         private const string CacheName = "Affecto.ActiveDirectoryService";
-        private const string GetPrincipalByAccountNameKey = "GetPrincipalByAccountNameKey";
-        private const string GetPrincipalByNativeGuidKey = "GetPrincipalByNativeGuidKey";
-        private const string GetGroupMembersKey = "GetGroupMembers";
+        private const string GetPrincipalByAccountNameKey = "GetPrincipalByAccountName";
+        private const string GetPrincipalByNativeGuidKey = "GetPrincipalByNativeGuid";
+        private const string GetGroupMembersByGroupNameKey = "GetGroupMembersByGroupName";
+        private const string GetGroupMembersByNativeGuidKey = "GetGroupMembersByNativeGuid";
         private const string GetGroupMemberAccountNamesKey = "GetGroupMemberAccountNames";
         private const string SearchPrincipalsKey = "SearchPrincipals";
         private const string ResolveMembersKey = "ResolveMembers";
@@ -19,7 +20,8 @@ namespace Affecto.ActiveDirectoryService
         {
             { GetPrincipalByAccountNameKey, new object() },
             { GetPrincipalByNativeGuidKey, new object() },
-            { GetGroupMembersKey, new object() },
+            { GetGroupMembersByGroupNameKey, new object() },
+            { GetGroupMembersByNativeGuidKey, new object() },
             { GetGroupMemberAccountNamesKey, new object() },
             { SearchPrincipalsKey, new object() },
             { ResolveMembersKey, new object() }
@@ -39,22 +41,28 @@ namespace Affecto.ActiveDirectoryService
             return GetCachedValue(GetPrincipalByAccountNameKey, cacheKey, () => base.GetPrincipal(accountName, additionalPropertyNames));
         }
 
-        public override IPrincipal GetPrincipal(Guid nativeGuid, ICollection<string> additionalPropertyNames = null)
+        public override IReadOnlyCollection<IPrincipal> GetGroupMembers(string groupName, bool recursive, ICollection<string> additionalPropertyNames = null)
         {
-            string cacheKey = CreateCacheKey(GetPrincipalByNativeGuidKey, nativeGuid.ToString("D"), FormatAdditionalPropertyNames(additionalPropertyNames));
-            return GetCachedValue(GetPrincipalByNativeGuidKey, cacheKey, () => base.GetPrincipal(nativeGuid, additionalPropertyNames));
+            string cacheKey = CreateCacheKey(GetGroupMembersByGroupNameKey, groupName, recursive.ToString(), FormatAdditionalPropertyNames(additionalPropertyNames));
+            return GetCachedValue(GetGroupMembersByGroupNameKey, cacheKey, () => base.GetGroupMembers(groupName, recursive, additionalPropertyNames));
         }
 
-        public override IEnumerable<IPrincipal> GetGroupMembers(string groupName, bool recursive, ICollection<string> additionalPropertyNames = null)
+        public override IReadOnlyCollection<IPrincipal> GetGroupMembers(Guid nativeGuid, bool recursive, ICollection<string> additionalPropertyNames = null)
         {
-            string cacheKey = CreateCacheKey(GetGroupMembersKey, groupName, recursive.ToString(), FormatAdditionalPropertyNames(additionalPropertyNames));
-            return GetCachedValue(GetGroupMembersKey, cacheKey, () => base.GetGroupMembers(groupName, recursive, additionalPropertyNames));
+            string cacheKey = CreateCacheKey(GetGroupMembersByNativeGuidKey, nativeGuid.ToString("N"), recursive.ToString(), FormatAdditionalPropertyNames(additionalPropertyNames));
+            return GetCachedValue(GetGroupMembersByNativeGuidKey, cacheKey, () => base.GetGroupMembers(nativeGuid, recursive, additionalPropertyNames));
         }
 
-        public override IEnumerable<IPrincipal> SearchPrincipals(string ldapFilter, ICollection<string> additionalPropertyNames = null)
+        public override IReadOnlyCollection<IPrincipal> SearchPrincipals(string ldapFilter, ICollection<string> additionalPropertyNames = null)
         {
             string cacheKey = CreateCacheKey(SearchPrincipalsKey, ldapFilter, FormatAdditionalPropertyNames(additionalPropertyNames));
             return GetCachedValue(SearchPrincipalsKey, cacheKey, () => base.SearchPrincipals(ldapFilter, additionalPropertyNames));
+        }
+
+        protected override Principal GetPrincipalInternal(Guid nativeGuid, ICollection<string> additionalPropertyNames = null)
+        {
+            string cacheKey = CreateCacheKey(GetPrincipalByNativeGuidKey, nativeGuid.ToString("N"), FormatAdditionalPropertyNames(additionalPropertyNames));
+            return GetCachedValue(GetPrincipalByNativeGuidKey, cacheKey, () => base.GetPrincipalInternal(nativeGuid, additionalPropertyNames));
         }
 
         protected override IEnumerable<string> GetGroupMemberAccountNames(string groupName)
@@ -63,7 +71,7 @@ namespace Affecto.ActiveDirectoryService
             return GetCachedValue(GetGroupMemberAccountNamesKey, cacheKey, () => base.GetGroupMemberAccountNames(groupName));
         }
 
-        protected override IEnumerable<IPrincipal> ResolveMembers(Principal parent, bool isRecursive, ICollection<string> additionalPropertyNames)
+        protected override IReadOnlyCollection<IPrincipal> ResolveMembers(Principal parent, bool isRecursive, ICollection<string> additionalPropertyNames)
         {
             string cacheKey = CreateCacheKey(ResolveMembersKey, parent.DomainPath, isRecursive.ToString(), FormatAdditionalPropertyNames(additionalPropertyNames));
             return GetCachedValue(ResolveMembersKey, cacheKey, () => base.ResolveMembers(parent, isRecursive, additionalPropertyNames));

--- a/ActiveDirectoryService/IActiveDirectoryService.cs
+++ b/ActiveDirectoryService/IActiveDirectoryService.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Affecto.ActiveDirectoryService
 {
     public interface IActiveDirectoryService
     {
         IPrincipal GetPrincipal(string accountName, ICollection<string> additionalPropertyNames = null);
+        IPrincipal GetPrincipal(Guid nativeGuid, ICollection<string> additionalPropertyNames = null);
         bool IsGroupMember(string accountName, string groupName);
         IEnumerable<IPrincipal> GetGroupMembers(string groupName, bool recursive, ICollection<string> additionalPropertyNames = null);
         IEnumerable<IPrincipal> SearchPrincipals(string ldapFilter, ICollection<string> additionalPropertyNames = null);

--- a/ActiveDirectoryService/IActiveDirectoryService.cs
+++ b/ActiveDirectoryService/IActiveDirectoryService.cs
@@ -4,8 +4,8 @@ namespace Affecto.ActiveDirectoryService
 {
     public interface IActiveDirectoryService
     {
-        IPrincipal GetUser(string userName, ICollection<string> additionalPropertyNames = null);
-        bool IsGroupMember(string userName, string groupName);
+        IPrincipal GetPrincipal(string accountName, ICollection<string> additionalPropertyNames = null);
+        bool IsGroupMember(string accountName, string groupName);
         IEnumerable<IPrincipal> GetGroupMembers(string groupName, bool recursive, ICollection<string> additionalPropertyNames = null);
         IEnumerable<IPrincipal> SearchPrincipals(string ldapFilter, ICollection<string> additionalPropertyNames = null);
     }

--- a/ActiveDirectoryService/IActiveDirectoryService.cs
+++ b/ActiveDirectoryService/IActiveDirectoryService.cs
@@ -8,7 +8,8 @@ namespace Affecto.ActiveDirectoryService
         IPrincipal GetPrincipal(string accountName, ICollection<string> additionalPropertyNames = null);
         IPrincipal GetPrincipal(Guid nativeGuid, ICollection<string> additionalPropertyNames = null);
         bool IsGroupMember(string accountName, string groupName);
-        IEnumerable<IPrincipal> GetGroupMembers(string groupName, bool recursive, ICollection<string> additionalPropertyNames = null);
-        IEnumerable<IPrincipal> SearchPrincipals(string ldapFilter, ICollection<string> additionalPropertyNames = null);
+        IReadOnlyCollection<IPrincipal> GetGroupMembers(string groupName, bool recursive, ICollection<string> additionalPropertyNames = null);
+        IReadOnlyCollection<IPrincipal> GetGroupMembers(Guid nativeGuid, bool recursive, ICollection<string> additionalPropertyNames = null);
+        IReadOnlyCollection<IPrincipal> SearchPrincipals(string ldapFilter, ICollection<string> additionalPropertyNames = null);
     }
 }

--- a/ActiveDirectoryService/IPrincipal.cs
+++ b/ActiveDirectoryService/IPrincipal.cs
@@ -5,7 +5,7 @@ namespace Affecto.ActiveDirectoryService
 {
     public interface IPrincipal
     {
-        string Id { get; }
+        string AccountName { get; }
         string DisplayName { get; }
         Guid NativeGuid { get; }
         string DomainPath { get; }

--- a/ActiveDirectoryService/Principal.cs
+++ b/ActiveDirectoryService/Principal.cs
@@ -8,7 +8,7 @@ namespace Affecto.ActiveDirectoryService
     internal class Principal : IPrincipal
     {
         public string DomainPath { get; private set; }
-        public string Id {get; private set;}
+        public string AccountName {get; private set;}
         public string DisplayName { get; private set; }
         public Guid NativeGuid { get; private set; }
         public bool IsGroup { get; private set; }
@@ -32,13 +32,13 @@ namespace Affecto.ActiveDirectoryService
 
             var principal = new Principal
             {
-                Id = directoryEntry.Properties[ActiveDirectoryProperties.AccountName].Value.ToString(),
+                AccountName = directoryEntry.Properties[ActiveDirectoryProperties.AccountName].Value.ToString(),
                 NativeGuid = new Guid(directoryEntry.NativeGuid),
                 DomainPath = directoryEntry.Path,
                 IsGroup = directoryEntry.SchemaClassName == ActiveDirectoryProperties.AccountGroup,
             };
 
-            principal.DisplayName = GetDisplayName(directoryEntry) ?? principal.Id;
+            principal.DisplayName = GetDisplayName(directoryEntry) ?? principal.AccountName;
             principal.AdditionalProperties = GetAdditionalProperties(directoryEntry, additionalPropertyNames);
             principal.ChildDomainPaths = GetChildDomainPaths(directoryEntry);
 

--- a/ActiveDirectoryService/PrincipalSearcher.cs
+++ b/ActiveDirectoryService/PrincipalSearcher.cs
@@ -47,7 +47,7 @@ namespace Affecto.ActiveDirectoryService
             return principal;
         }
 
-        public IEnumerable<Principal> FindPrincipals(string ldapFilter)
+        public IReadOnlyCollection<Principal> FindPrincipals(string ldapFilter)
         {
             return FindAllPrincipals(ldapFilter);
         }

--- a/ActiveDirectoryService/Properties/AssemblyInfo.cs
+++ b/ActiveDirectoryService/Properties/AssemblyInfo.cs
@@ -9,6 +9,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyFileVersion("3.0.0.0")]
 
 // This version is used by NuGet:
-[assembly: AssemblyInformationalVersion("3.0.0-prerelease01")]
+[assembly: AssemblyInformationalVersion("3.0.0")]
 
 [assembly: InternalsVisibleTo("Affecto.ActiveDirectoryService.Tests")]

--- a/ActiveDirectoryService/Properties/AssemblyInfo.cs
+++ b/ActiveDirectoryService/Properties/AssemblyInfo.cs
@@ -5,10 +5,10 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Wraps Microsoft Active Directory services.")]
 [assembly: AssemblyCompany("Affecto")]
 
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]
 
 // This version is used by NuGet:
-[assembly: AssemblyInformationalVersion("2.1.0")]
+[assembly: AssemblyInformationalVersion("3.0.0-prerelease01")]
 
 [assembly: InternalsVisibleTo("Affecto.ActiveDirectoryService.Tests")]

--- a/Tester/Program.cs
+++ b/Tester/Program.cs
@@ -1,6 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
+using System.Diagnostics;
+using System.DirectoryServices;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Affecto.ActiveDirectoryService.Tester
 {
@@ -8,10 +12,39 @@ namespace Affecto.ActiveDirectoryService.Tester
     {
         static void Main()
         {
-            IActiveDirectoryService service = ActiveDirectoryServiceFactory.CreateActiveDirectoryService(ConfigurationManager.AppSettings["domainPath"]);
-            List<IPrincipal> principals = service.GetGroupMembers("", true, new List<string> {  }).ToList();
-            IPrincipal principal = service.GetUser("", new List<string> { });
-            bool isGroupMember = service.IsGroupMember("", "");
+            IActiveDirectoryService service = ActiveDirectoryServiceFactory.CreateCachedActiveDirectoryService(ConfigurationManager.AppSettings["domainPath"], TimeSpan.FromMinutes(5));
+
+            List<IPrincipal> principals = service.SearchPrincipals("(&(objectClass=person)(sn=*)(company=*)(!userAccountControl:1.2.840.113556.1.4.803:=2)(department=*)(title=*))",
+                new List<string> { "extensionAttribute8", "department", "company", "division" })
+                .ToList();
+
+            foreach (IPrincipal principal in principals.OrderBy(p => p.DisplayName))
+            {
+                Debug.WriteLine(principal.DisplayName);
+            }
+
+            List<IPrincipal> principals2 = service.SearchPrincipals("(&(objectClass=person)(sn=*)(company=*)(!userAccountControl:1.2.840.113556.1.4.803:=2)(department=*)(title=*))",
+                new List<string> { "extensionAttribute8", "department", "company", "division" })
+                .ToList();
+
+            //IActiveDirectoryService service = ActiveDirectoryServiceFactory.CreateCachedActiveDirectoryService(ConfigurationManager.AppSettings["domainPath"],
+            //    TimeSpan.FromMinutes(5));
+
+            //Task<List<IPrincipal>> task = Task.Factory.StartNew(() => service.GetGroupMembers("turku-list", true, new List<string> { "thumbnailPhoto" }).ToList());
+
+            //System.Threading.Thread.Sleep(2000);
+
+            //IPrincipal principal = service.GetPrincipal("valtojoh", new List<string> { "thumbnailPhoto" });
+
+            //List<IPrincipal> principals = service.GetGroupMembers("turku-list", true, new List<string> { }).ToList();
+
+
+            ////IPrincipal principal = service.GetPrincipal("", new List<string> { });
+            //bool isGroupMember = service.IsGroupMember("valtojoh", "turku-list");
+
+            //List<IPrincipal> principals2 = service.GetGroupMembers("turku-list", true, new List<string> { }).ToList();
+
+            //task.Wait();
         }
     }
 }

--- a/Tester/Tester.csproj
+++ b/Tester/Tester.csproj
@@ -35,6 +35,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.DirectoryServices" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Tester/Tester.csproj
+++ b/Tester/Tester.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Affecto.ActiveDirectoryService.Tester</RootNamespace>
     <AssemblyName>Affecto.ActiveDirectoryService.Tester</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -21,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -30,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,5 +16,4 @@ deploy:
   api_key:
     secure: ySttUuKXaqz/qn7dZRtJJs7H8wTDgT8Wgi55QFGZjmVE2XL14T2puaPiBcNMZC1l
   on:
-    branch: master
     appveyor_repo_tag: true


### PR DESCRIPTION
- Raised to .NET Framework 4.5.2. 
- Added a method for getting principal by its native GUID. 
- Added a method for getting group members by group native GUID. 
- Renamed methods and properties to make them more consistent.
